### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/UC2_mobile_contribution/broadcaster/service/Dockerfile
+++ b/UC2_mobile_contribution/broadcaster/service/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask>=1.0.0 requests==2.13.0 kafka-python==1.4.2 pyopenssl
 
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=EU/ST=5gmedia 5gmedia/L=5gmedia /O=5gmedia/OU=5gmedia/CN=5gmedia/emailAddress=5gmedia" -keyout /server.key -out /server.crt

--- a/kubernetes/proxier-service/Dockerfile
+++ b/kubernetes/proxier-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker5gmedia/ow-offload-serverprereqs:0.1
 
-RUN pip install \
+RUN pip install --no-cache-dir \
     kubernetes==10.0.1
 
 RUN mkdir -p /proxyServer

--- a/kubernetes/service/Dockerfile.prereq
+++ b/kubernetes/service/Dockerfile.prereq
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash \
         bzip2-dev \
         gcc \
         libc-dev \
-  && pip install --upgrade pip setuptools \
+  && pip install --no-cache-dir --upgrade pip setuptools \
   && pip install --no-cache-dir gevent==1.2.1 flask==0.12 \
   && apk del .build-deps
 
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
         openssl-dev
 
 # Install common modules for python
-RUN pip install \
+RUN pip install --no-cache-dir \
     beautifulsoup4==4.5.3 \
     httplib2==0.10.3 \
     kafka_python==1.3.2 \

--- a/openwhisk/docker/Dockerfile.base
+++ b/openwhisk/docker/Dockerfile.base
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask==0.12 requests==2.13.0
 
 # Do not modify - this is the internal openwhisk invoker service port

--- a/openwhisk/docker/Dockerfile.base.18.04
+++ b/openwhisk/docker/Dockerfile.base.18.04
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask==0.12 requests==2.13.0
 
 # Do not modify - this is the internal openwhisk invoker service port

--- a/openwhisk/docker/Dockerfile.base.gpu
+++ b/openwhisk/docker/Dockerfile.base.gpu
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask==0.12 requests==2.13.0
 
 # Do not modify - this is the internal openwhisk invoker service port

--- a/openwhisk/docker/Dockerfile.base.gpu.ds061-cc61
+++ b/openwhisk/docker/Dockerfile.base.gpu.ds061-cc61
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask==0.12 requests==2.13.0
 
 # Do not modify - this is the internal openwhisk invoker service port

--- a/vim-plugin/configuration_service/Dockerfile
+++ b/vim-plugin/configuration_service/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y bash \
     libc-dev \
     python-pip
 
-RUN pip install --upgrade pip setuptools six
+RUN pip install --no-cache-dir --upgrade pip setuptools six
 RUN pip install --no-cache-dir gevent==1.2.1 flask==0.12 requests==2.13.0
 
 ADD faas_configuration_service.py /


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>